### PR TITLE
TaxSystemCode должен быть числом

### DIFF
--- a/Yandex.Checkout.V3/TaxSystem.cs
+++ b/Yandex.Checkout.V3/TaxSystem.cs
@@ -6,7 +6,6 @@ namespace Yandex.Checkout.V3
     /// <summary>
     /// Коды систем налогообложения
     /// </summary>
-    [JsonConverter(typeof(StringEnumConverter))]
     public enum TaxSystem
     {
         /// <summary>


### PR DESCRIPTION
Добрый день. Судя по документации, код системы налогообложения должен быть числом:

![image](https://user-images.githubusercontent.com/1222013/69120179-b419b580-0aba-11ea-9e36-b32d9043668d.png)

Если использовать `StringEnumConverter`, то получаем ошибку:

```
{
  "type": "error",
  "id": "0f7f1977-e63d-4926-b1ba-54fd6bc5d3f6",
  "code": "invalid_request",
  "description": "Invalid request parameter",
  "parameter": "receipt.tax_system_code"
}
```