### PR TITLE
feat: Add HttpClient to MakeAsync

### DIFF
--- a/Yandex.Checkout.V3/ClientExtensions.cs
+++ b/Yandex.Checkout.V3/ClientExtensions.cs
@@ -1,28 +1,20 @@
-﻿using System;
+using System;
 using System.Net.Http;
 
 namespace Yandex.Checkout.V3
 {
     public static class ClientExtensions
     {
-        public static AsyncClient MakeAsync(this Client client) => 
-            new(NewHttpClient(client), true);
-
-        public static AsyncClient MakeAsync(this Client client, TimeSpan timeout)
+        public static AsyncClient MakeAsync(this Client client, TimeSpan? timeout = null, HttpClient httpClient = null)
         {
-            HttpClient httpClient = NewHttpClient(client);
-            httpClient.Timeout = timeout;
-            return new AsyncClient(httpClient, true);
-        }
-
-        private static HttpClient NewHttpClient(Client client)
-        {
-            var httpClient = new HttpClient {BaseAddress = new Uri(client.ApiUrl)};
+            httpClient ??= new HttpClient();
+            httpClient.BaseAddress = new Uri(client.ApiUrl);
             httpClient.DefaultRequestHeaders.Add("Authorization", client.Authorization);
-
-            if (!string.IsNullOrEmpty(client.UserAgent))
-                httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(client.UserAgent);
-            return httpClient;
+            if (timeout.HasValue)
+            {
+                httpClient.Timeout = timeout.Value;
+            }
+            return new AsyncClient(httpClient, true);
         }
     }
 }

--- a/Yandex.Checkout.V3/ClientExtensions.cs
+++ b/Yandex.Checkout.V3/ClientExtensions.cs
@@ -21,6 +21,10 @@ namespace Yandex.Checkout.V3
             }
             httpClient.BaseAddress = new Uri(client.ApiUrl);
             httpClient.DefaultRequestHeaders.Add("Authorization", client.Authorization);
+            if (!string.IsNullOrEmpty(client.UserAgent))
+            {
+                httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(client.UserAgent);
+            }
             if (timeout.HasValue)
             {
                 httpClient.Timeout = timeout.Value;

--- a/Yandex.Checkout.V3/ClientExtensions.cs
+++ b/Yandex.Checkout.V3/ClientExtensions.cs
@@ -5,8 +5,19 @@ namespace Yandex.Checkout.V3
 {
     public static class ClientExtensions
     {
-        public static AsyncClient MakeAsync(this Client client, TimeSpan? timeout = null, HttpClient httpClient = null)
+        public static AsyncClient MakeAsync(this Client client) =>
+            MakeAsync(client, null, null, true);
+
+        public static AsyncClient MakeAsync(this Client client, TimeSpan timeout) =>
+            MakeAsync(client, timeout, null, true);
+
+        public static AsyncClient MakeAsync(this Client client, TimeSpan? timeout,
+            HttpClient httpClient, bool disposeOfHttpClient = false)
         {
+            if (httpClient == null)
+            {
+                disposeOfHttpClient = true;
+            }
             httpClient ??= new HttpClient();
             httpClient.BaseAddress = new Uri(client.ApiUrl);
             httpClient.DefaultRequestHeaders.Add("Authorization", client.Authorization);
@@ -14,7 +25,7 @@ namespace Yandex.Checkout.V3
             {
                 httpClient.Timeout = timeout.Value;
             }
-            return new AsyncClient(httpClient, true);
+            return new AsyncClient(httpClient, disposeOfHttpClient);
         }
     }
 }

--- a/Yandex.Checkout.V3/ClientExtensions.cs
+++ b/Yandex.Checkout.V3/ClientExtensions.cs
@@ -16,9 +16,9 @@ namespace Yandex.Checkout.V3
         {
             if (httpClient == null)
             {
+                httpClient = new HttpClient();
                 disposeOfHttpClient = true;
             }
-            httpClient ??= new HttpClient();
             httpClient.BaseAddress = new Uri(client.ApiUrl);
             httpClient.DefaultRequestHeaders.Add("Authorization", client.Authorization);
             if (timeout.HasValue)


### PR DESCRIPTION
Конструктор AsyncClient [ожидает](https://github.com/morpher-ru/Yandex.Checkout.V3/blob/0b1c45f947bcf10abf692478e264e6fa19c04651/Yandex.Checkout.V3/AsyncClient.cs#L16), что HttpClient сконфигурирован. В то же время нет метода, который бы конфигурировал сторонний HttpClient (например, полученный из [IHttpClientFactory](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests)). 

Предлагаю такой вариант.