### PR TITLE
Allow use of an existing HttpClient in MakeAsync()

### DIFF
--- a/Yandex.Checkout.V3.Tests/AsyncClientTests.cs
+++ b/Yandex.Checkout.V3.Tests/AsyncClientTests.cs
@@ -69,9 +69,12 @@ namespace Yandex.Checkout.V3.Tests
             var messageHandler = new TestMessageHandler();
             messageHandler.ResponseQueue.Enqueue(httpResponseMessage);
 
-            var httpClient = new HttpClient(messageHandler) {BaseAddress = new Uri("http://ym.com")};
+            var httpClient = new HttpClient(messageHandler);
 
-            var asyncClient = new AsyncClient(httpClient);
+            var client = new Client("test_shop_id", "test_key", "http://ym.com");
+            
+            var asyncClient = new AsyncClient(httpClient, false, client);
+            
             await action(asyncClient);
         }
     }

--- a/Yandex.Checkout.V3/ClientExtensions.cs
+++ b/Yandex.Checkout.V3/ClientExtensions.cs
@@ -14,15 +14,26 @@ public static class ClientExtensions
         return new AsyncClient(httpClient, true);
     }
 
+    public static AsyncClient MakeAsync(this Client client, HttpClient httpClient)
+    {
+        SetHttpClientProperties(client, httpClient);
+        return new AsyncClient(httpClient, disposeOfHttpClient: false);
+    }
+
     private static HttpClient NewHttpClient(Client client)
     {
-        var httpClient = new HttpClient {BaseAddress = new Uri(client.ApiUrl)};
-        
+        var httpClient = new HttpClient();
+        SetHttpClientProperties(client, httpClient);
+        return httpClient;
+    }
+
+    private static void SetHttpClientProperties(Client client, HttpClient httpClient)
+    {
+        httpClient.BaseAddress = new Uri(client.ApiUrl);
+
         httpClient.DefaultRequestHeaders.Add("Authorization", client.Authorization);
 
         if (!string.IsNullOrEmpty(client.UserAgent))
             httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(client.UserAgent);
-        
-        return httpClient;
     }
 }

--- a/Yandex.Checkout.V3/ClientExtensions.cs
+++ b/Yandex.Checkout.V3/ClientExtensions.cs
@@ -5,35 +5,25 @@ namespace Yandex.Checkout.V3;
 public static class ClientExtensions
 {
     public static AsyncClient MakeAsync(this Client client) => 
-        new(NewHttpClient(client), true);
+        new(NewHttpClient(), true, client);
 
     public static AsyncClient MakeAsync(this Client client, TimeSpan timeout)
     {
-        HttpClient httpClient = NewHttpClient(client);
+        HttpClient httpClient = NewHttpClient();
         httpClient.Timeout = timeout;
-        return new AsyncClient(httpClient, true);
+        return new AsyncClient(httpClient, true, client);
     }
 
+    /// <summary>
+    /// Creates an AsyncClient that uses the given HttpClient.
+    /// </summary>
     public static AsyncClient MakeAsync(this Client client, HttpClient httpClient)
     {
-        SetHttpClientProperties(client, httpClient);
-        return new AsyncClient(httpClient, disposeOfHttpClient: false);
+        return new AsyncClient(httpClient, disposeOfHttpClient: false, client);
     }
 
-    private static HttpClient NewHttpClient(Client client)
+    private static HttpClient NewHttpClient()
     {
-        var httpClient = new HttpClient();
-        SetHttpClientProperties(client, httpClient);
-        return httpClient;
-    }
-
-    private static void SetHttpClientProperties(Client client, HttpClient httpClient)
-    {
-        httpClient.BaseAddress = new Uri(client.ApiUrl);
-
-        httpClient.DefaultRequestHeaders.Add("Authorization", client.Authorization);
-
-        if (!string.IsNullOrEmpty(client.UserAgent))
-            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(client.UserAgent);
+        return new HttpClient();
     }
 }


### PR DESCRIPTION
Позволяет использовать созданный ранее HttpClient (например, статический или полученный из IHttpClientFactory) в AsyncClient. Альтернатива PR #68. 